### PR TITLE
Bump onnx version to 1.4.1 as required.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.15.1
-onnx>=1.1.1
+onnx==1.4.1
 pycuda>=2017.1.1
 Pillow>=5.2.0
 wget>=3.2


### PR DESCRIPTION
Make `requirements.txt` great again.
Now it is consistent with the readme.md
